### PR TITLE
Remove release-3_22 from testing matrix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,6 +25,7 @@ jobs:
 
     strategy:
       matrix:
+        # release-3_22 removed due to QGIS docker build issues
         docker_tags: [release-3_28, latest]
 
     steps:


### PR DESCRIPTION
Until QGIS docker issues are resolved. https://github.com/qgis/QGIS/issues/50729