### PR TITLE
Use QWidget.window() rather than QWidget.screen()

### DIFF
--- a/koordinates/gui/dataset_browser_items.py
+++ b/koordinates/gui/dataset_browser_items.py
@@ -527,7 +527,7 @@ class DatasetItemWidget(DatasetItemWidgetBase):
 
     def update_thumbnail(self):
         thumbnail = self.process_thumbnail(self.raw_thumbnail)
-        dpi_ratio = self.screen().devicePixelRatio()
+        dpi_ratio = self.window().screen().devicePixelRatio()
         width = int(thumbnail.width() / dpi_ratio)
         height = int(thumbnail.height() / dpi_ratio)
         self.thumbnail_label.setFixedSize(QSize(width, height))
@@ -541,7 +541,7 @@ class DatasetItemWidget(DatasetItemWidgetBase):
             size = QSize(self.width(), self.THUMBNAIL_SIZE)
 
         image_size = size
-        scale_factor = self.screen().devicePixelRatio()
+        scale_factor = self.window().screen().devicePixelRatio()
         if scale_factor > 1:
             image_size *= scale_factor
 

--- a/koordinates/gui/dataset_dialog.py
+++ b/koordinates/gui/dataset_dialog.py
@@ -780,7 +780,7 @@ class DatasetDialog(QDialog):
 
     def setThumbnail(self, img):
         image_size = self.thumbnail_label.size()
-        scale_factor = self.screen().devicePixelRatio()
+        scale_factor = self.window().screen().devicePixelRatio()
         if scale_factor > 1:
             image_size *= scale_factor
 

--- a/koordinates/gui/koordinates.py
+++ b/koordinates/gui/koordinates.py
@@ -412,7 +412,7 @@ class Koordinates(QgsDockWidget, WIDGET):
         self.filter_widget.clear_all.connect(self._clear_all_filters)
         self.filter_widget.clear_all.connect(self.advanced_filter_widget.clear_all)
 
-        if os.name == 'nt' or self.screen().devicePixelRatio() > 1:
+        if os.name == 'nt' or self.window().screen().devicePixelRatio() > 1:
             self.button_sort_order.setStyleSheet(
                 'QToolButton { padding-right: 30px; padding-left: 0px; }'
             )


### PR DESCRIPTION
To support builds of QGIS against QT before 5.14 and deal with #168 