### PR TITLE
Use a different approach to show filter combobox custom widgets

### DIFF
--- a/koordinates/gui/custom_combo_box.py
+++ b/koordinates/gui/custom_combo_box.py
@@ -24,7 +24,6 @@ from qgis.PyQt.QtWidgets import (
     QVBoxLayout,
     QComboBox,
     QStyleOptionComboBox,
-    QApplication,
     QSizePolicy
 )
 from qgis.core import (


### PR DESCRIPTION
Ensures that these widgets are dismissed whenever clicks occur ANYWHERE outside the filter widget

Fixes #212