### PR TITLE
Force truncate titles in cards to <70 characters

### DIFF
--- a/koordinates/gui/dataset_browser_items.py
+++ b/koordinates/gui/dataset_browser_items.py
@@ -715,10 +715,14 @@ class DatasetItemWidget(DatasetItemWidgetBase):
 
         publisher_name = self.dataset.publisher().name() if \
             self.dataset.publisher() else ''
+        title = self.dataset.title()
+        max_title_length = 70
+        if len(title) > max_title_length:
+            title = title[:max_title_length - 3] + '...'
         self.title_label.setText(
             f"""<p style="line-height: 130%;
                 font-size: {main_title_size}pt;
-                font-family: Arial, Sans"><b>{self.dataset.title()}</b><br>"""
+                font-family: Arial, Sans"><b>{title}</b><br>"""
             f"""<span style="color: #868889;
             font-size: {title_font_size}pt;
             font-family: Arial, Sans">{publisher_name}</span></p>"""

--- a/koordinates/gui/dataset_browser_items.py
+++ b/koordinates/gui/dataset_browser_items.py
@@ -424,8 +424,8 @@ class DatasetItemLayout(QLayout):
             if self.details_container:
                 self.details_container.setGeometry(
                     QRect(
-                        left, 35,
-                        105,
+                        left, 60,
+                        85,
                         61
                     )
                 )

--- a/koordinates/gui/elided_label.py
+++ b/koordinates/gui/elided_label.py
@@ -1,0 +1,57 @@
+from typing import Optional
+
+from qgis.PyQt.QtGui import (
+    QPainter,
+    QFontMetrics
+)
+from qgis.PyQt.QtWidgets import (
+    QWidget,
+    QLabel
+)
+
+
+class ElideLabel(QLabel):
+    """
+    A label which automatically elides its text if it is too long to
+    fit into the label
+    """
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+
+    def paintEvent(self, event):
+        if not self.ugly_mode:
+            painter = QPainter(self)
+            fm = QFontMetrics(self.font())
+
+            # subtract 2 for a little padding
+            available_width = self.width() - 2
+            available_height = self.height() - 2
+
+            # gross, let's reimplement a LOT of qt internals!
+            current_x = 0
+            current_y = fm.height()
+            words = self.text().split(' ')
+            space_width = fm.width(' ')
+            line_space = fm.lineSpacing()
+
+            painter.setFont(self.font())
+
+            word_pos = []
+
+            for word in words:
+                word_width = fm.width(word)
+                current_x += word_width
+                if current_x > available_width:
+                    current_x = word_width
+                    current_y += line_space
+                    if current_y > available_height:
+                        if word_pos:
+                            word_pos[-1][2] = '...'
+                        break
+                word_pos.append([current_x - word_width, current_y, word])
+
+                current_x += space_width
+
+            for x, y, word in word_pos:
+                painter.drawText(x, y, word)


### PR DESCRIPTION
Avoids titles overflowing onto other parts of cards. Unfortunately
this is a very crude approach, in that we can't actually account
for the length of words and the actual text wrapping positions
due to the use of HTML characters in the title label

Fixes https://github.com/koordinates/koordinates-qgis-plugin/issues/295