### PR TITLE
Partially revert "Don't filter panels on client"

### DIFF
--- a/koordinates/gui/results_panel/results_panel.py
+++ b/koordinates/gui/results_panel/results_panel.py
@@ -253,10 +253,20 @@ class ResultsPanel(QWidget):
             print('error occurred :(')
             return
 
+        filtered_panels = []
+        for panel in result['panels']:
+            # filter panel items to supported ones
+            panel['items'] = [item for item in panel['items']
+                              if item['kind'] not in ('publisher.site',
+                                                      'publisher.mirror')]
+            # and then completely skip any empty panels
+            if panel['items']:
+                filtered_panels.append(panel)
+
         mode = ExploreMode.Popular if explore_panel == ExplorePanel.Popular \
             else ExplorePanel.Recent
 
-        for panel in result['panels']:
+        for panel in filtered_panels:
             item = ExplorePanelWidget(panel, mode=mode)
             self.child_items.append(item)
             self.container_layout.addWidget(item)


### PR DESCRIPTION
This partially reverts commit 17e22f4a0db66064b1c00e62f46f9fae415d8a82. We need to still filter out panel items which aren't supported by the client (eg publisher.site), and then skip any empty panels

Fixes #294