### PR TITLE
Update download-artifact workflow action to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         echo ${{ github.event.pull_request.head.sha }} | tee git_commit
         echo ${{ github.event.number }}
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: koordinates_package.${{ env.VERSION }}
         path: tmp


### PR DESCRIPTION
We were using v2 which has been deprecated and disabled.