### PR TITLE
Fix plugin packaging for upload to QGIS plugin registry

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -37,6 +37,7 @@ def package(version=None):
         buf = StringIO()
         cfg.write(buf)
         zipFile.writestr("koordinates/metadata.txt", buf.getvalue())
+        zipFile.write("LICENSE", "koordinates/LICENSE")
 
         def filter_excludes(files):
             if not files:

--- a/koordinates/metadata.txt
+++ b/koordinates/metadata.txt
@@ -15,7 +15,7 @@ about=<div style="max-width:33em">The <a href="https://koordinates.com/explore/"
 version=2.1.0
 author=Koordinates
 email=support@koordinates.com
-tags=versioning, data, cloning, collections, access, discoverablity, open data
+tags=versioning, data, cloning, collections, access, discoverability, open data
 homepage=https://koordinates.com
 repository=https://github.com/koordinates/koordinates-qgis-plugin
 tracker=https://github.com/koordinates/koordinates-qgis-plugin/issues


### PR DESCRIPTION
In release v3.0.2 the upload to QGIS plugin registry failed.

https://github.com/koordinates/koordinates-qgis-plugin/actions/runs/11583993791

```
mlrpc.client.Fault: <Fault 1: "<Fault 1: 'File upload must be a valid QGIS Python plugin compressed archive. Cannot find LICENSE in the plugin package. This file is required, please consider adding it to the plugin package.'>">
```

This appears to be a new requirement for uploaded plugin packages.

This change copies the repository LICENSE into the package zip.