### PR TITLE
An attempt at working around kart message encoding issues

### DIFF
--- a/koordinates/core/kart_task.py
+++ b/koordinates/core/kart_task.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from typing import (
     List,
     Optional,
@@ -86,7 +87,14 @@ class KartTask(QgsTask):
         """
         Called when the kart process emits messages on stdout
         """
-        val = ba.data().decode('UTF-8')
+        try:
+            val = ba.data().decode('UTF-8')
+        except UnicodeDecodeError:
+            try:
+                val = ba.data().decode(sys.getdefaultencoding())
+            except UnicodeDecodeError:
+                val = str(ba.data())
+
         self._stdout_buffer += val
 
         if self._stdout_buffer.endswith('\n') or self._stdout_buffer.endswith(


### PR DESCRIPTION
In some situations Kart is emitting messages that cannot be decoded as UTF-8.

```
File "C:\Users/xxxxxxx/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\koordinates\core\kart_task.py", line 106, in on_stdout
  self.on_stdout(ba)
  ^^^^^^^^^^^^^^
  File "C:\Users/xxxxxxx/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\koordinates\core\kart_task.py", line 106, in on_stdout
  self.on_stdout(ba)
  ^^^^^^^^^^^^^^
  File "C:\Users/xxxxxxx/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\koordinates\core\kart_task.py", line 106, in on_stdout
  self.on_stdout(ba)
  ^^^^^^^^^^^^^^
  [Previous line repeated 5 more times]
  File "C:\Users/xxxxxxx/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\koordinates\core\kart_task.py", line 185, in on_stdout
  val = ba.data().decode('UTF-8')
  ^^^^^^^^^^^^^^^^^^^^^^^^^
 UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 117: invalid continuation byte
 
 The above exception was the direct cause of the following exception:
 
 SystemError: returned a result with an exception set
 
 The above exception was the direct cause of the following exception:
 
 SystemError: returned a result with an exception set
 
 The above exception was the direct cause of the following exception:
 
 Traceback (most recent call last):
  File "C:\Users/xxxxxxx/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\koordinates\core\kart_task.py", line 211, in run
  res = super().run()
  ^^^^^^^^^^^^^
  File "C:\Users/xxxxxxx/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\koordinates\core\kart_task.py", line 113, in run
  res = process.run(self._feedback)
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 SystemError: returned a result with an exception set
```

We're yet to understand the exact source of the message and haven't been able to reproduce outside of a particular environment, however this change attempts to harden the decode of the CLI response.