### PR TITLE
Fixes text encoding issues in output handling during clones

### DIFF
--- a/koordinates/core/kart_task.py
+++ b/koordinates/core/kart_task.py
@@ -86,7 +86,7 @@ class KartTask(QgsTask):
         """
         Called when the kart process emits messages on stdout
         """
-        val = ba.data().decode('UTF-8')
+        val = ba.data().decode('UTF-8', errors='replace')
         self._stdout_buffer += val
 
         if self._stdout_buffer.endswith('\n') or self._stdout_buffer.endswith(
@@ -182,7 +182,7 @@ class KartCloneTask(KartTask):
         ).format(self.title)
 
     def on_stdout(self, ba):
-        val = ba.data().decode('UTF-8')
+        val = ba.data().decode('UTF-8', errors='replace')
 
         counting_regex = re.compile(r'.*Counting objects:?\s*(\d+)%.*')
         receiving_regex = re.compile(r'.*Receiving objects:?\s*(\d+)%.*')


### PR DESCRIPTION
When a dataset name includes special characters there can sometimes be issues handling kart clone output that causes error messages to be displayed and the repos are not added to the manager.

Despite this, the repository is cloned successfully on disk and can be manually added.

This change allows for unexpected encoding issues that don't impact on the normal operation of the plugin to be ignored.