### PR TITLE
Fixes clone action for Repository datasets

### DIFF
--- a/koordinates/api/dataset.py
+++ b/koordinates/api/dataset.py
@@ -233,17 +233,26 @@ class Dataset:
         """
         Returns the repository information for the dataset
         """
+
         if self._repository is not None:
             return self._repository
 
-        repo_detail_url = self.details.get('repository')
-        if repo_detail_url and isinstance(repo_detail_url, dict):
-            self._repository = Repo(repo_detail_url)
-        elif repo_detail_url:
-            from .client import KoordinatesClient
-            self._repository = KoordinatesClient.instance().retrieve_repository(
-                repo_detail_url
-            )
+        if self.datatype == DataType.Repositories:
+            # Set repository for the existing dataset detail:
+            self._repository = Repo(self.details)
+
+        else:
+            repo_detail_url = self.details.get("repository")
+            if repo_detail_url and isinstance(repo_detail_url, dict):
+                # Set repository from the already available repo detail:
+                self._repository = Repo(repo_detail_url)
+            elif repo_detail_url:
+                # Set the repsository from the fetched repo detail response:
+                from .client import KoordinatesClient
+
+                self._repository = KoordinatesClient.instance().retrieve_repository(
+                    repo_detail_url
+                )
 
         return self._repository
 

--- a/koordinates/api/utils.py
+++ b/koordinates/api/utils.py
@@ -93,21 +93,26 @@ class ApiUtils:
         datatype = ApiUtils.data_type_from_dataset_response(dataset)
         capabilities = DataType.capabilities(datatype)
 
-        if not dataset.get("repository"):
+        if datatype == DataType.Repositories:
+            repo_user_capabilities = dataset.get("user_capabilities", [])
+            if "can-clone" not in repo_user_capabilities:
+                capabilities.remove(Capability.Clone)
+            if "can-request-clone" in repo_user_capabilities:
+                capabilities.add(Capability.RequestClone)
+
+        elif not dataset.get("repository"):
             capabilities.remove(Capability.Clone)
+
         else:
             repo = dataset["repository"]
             if repo and not isinstance(repo, dict):
                 from .client import KoordinatesClient
-                repo = KoordinatesClient.instance().get_json(
-                    repo
-                )
-            repo_user_capabilities = repo.get(
-                "user_capabilities", []
-            )
-            if 'can-clone' not in repo_user_capabilities:
+
+                repo = KoordinatesClient.instance().get_json(repo)
+            repo_user_capabilities = repo.get("user_capabilities", [])
+            if "can-clone" not in repo_user_capabilities:
                 capabilities.remove(Capability.Clone)
-            if 'can-request-clone' in repo_user_capabilities:
+            if "can-request-clone" in repo_user_capabilities:
                 capabilities.add(Capability.RequestClone)
 
         return capabilities

--- a/koordinates/test/test_api_utils.py
+++ b/koordinates/test/test_api_utils.py
@@ -171,8 +171,7 @@ class TestApiUtils(unittest.TestCase):
         self.assertEqual(ApiUtils.capabilities_from_dataset_response(
             {
                 'type': 'repo',
-                'repository': {'id': 'something',
-                               'user_capabilities': ['can-clone']}
+                'user_capabilities': ['can-clone']
             }), {Capability.Clone, Capability.RevisionCount})
         self.assertEqual(ApiUtils.capabilities_from_dataset_response(
             {


### PR DESCRIPTION
Repositories can be listed in the plugin data browser but are missing the Clone button.

This fixes the lookups for the Clone capability and returns the correct Repo object for the Repository dataset type.
